### PR TITLE
Added local and session storage

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,6 +1,6 @@
 name = "plinth"
-version = "0.1.1"
-description = "A Gleam project"
+version = "0.1.2"
+description = "Bindings to Node.js and browser platform APIs"
 target = "javascript"
 
 # Fill out these fields if you intend to generate HTML documentation or publish

--- a/src/plinth/javascript/storage.gleam
+++ b/src/plinth/javascript/storage.gleam
@@ -1,0 +1,42 @@
+//// Bindings to local and session storage.
+
+/// A Storage object (local or session).
+/// 
+/// See [https://developer.mozilla.org/en-US/docs/Web/API/Storage](https://developer.mozilla.org/en-US/docs/Web/API/Storage).
+pub type Storage
+
+/// Attempts to get the local storage object, fails if it's not available.
+@external(javascript, "../../storage_ffi.mjs", "localStorage")
+pub fn local() -> Result(Storage, Nil)
+
+/// Attempts to get the session storage object, fails if it's not available.
+@external(javascript, "../../storage_ffi.mjs", "sessionStorage")
+pub fn session() -> Result(Storage, Nil)
+
+/// Returns the amount of items in the storage.
+@external(javascript, "../../storage_ffi.mjs", "length")
+pub fn length(storage: Storage) -> Int
+
+/// Returns the key of the item with the index `index`, if it exists.
+@external(javascript, "../../storage_ffi.mjs", "key")
+pub fn key(storage: Storage, index: Int) -> Result(String, Nil)
+
+/// Returns the item with the specified key, if it exists.
+@external(javascript, "../../storage_ffi.mjs", "getItem")
+pub fn get_item(storage: Storage, key: String) -> Result(String, Nil)
+
+/// Adds or updates an item with the specified key. If the storage is full, an error is returned.
+@external(javascript, "../../storage_ffi.mjs", "setItem")
+pub fn set_item(
+  storage: Storage,
+  key: String,
+  value: String,
+) -> Result(Nil, Nil)
+
+/// Removes an item with the specified key.
+@external(javascript, "../../storage_ffi.mjs", "removeItem")
+pub fn remove_item(storage: Storage, key: String) -> Nil
+
+/// Clears the storage of all items.
+@external(javascript, "../../storage_ffi.mjs", "clear")
+pub fn clear(storage: Storage) -> Nil

--- a/src/storage_ffi.mjs
+++ b/src/storage_ffi.mjs
@@ -1,0 +1,68 @@
+import { Ok, Error } from "./gleam.mjs";
+
+export function localStorage() {
+  try {
+    if (
+      globalThis.Storage &&
+      globalThis.localStorage instanceof globalThis.Storage
+    ) {
+      return new Ok(globalThis.localStorage);
+    } else {
+      return new Error(null);
+    }
+  } catch {
+    return new Error(null);
+  }
+}
+
+export function sessionStorage() {
+  try {
+    if (
+      globalThis.Storage &&
+      globalThis.sessionStorage instanceof globalThis.Storage
+    ) {
+      return new Ok(globalThis.sessionStorage);
+    } else {
+      return new Error(null);
+    }
+  } catch {
+    return new Error(null);
+  }
+}
+
+export function length(storage) {
+  return storage.length;
+}
+
+export function key(storage, index) {
+  return null_or(storage.key(index));
+}
+
+export function getItem(storage, keyName) {
+  return null_or(storage.getItem(keyName));
+}
+
+export function setItem(storage, keyName, keyValue) {
+  try {
+    storage.setItem(keyName, keyValue);
+    return new Ok(null);
+  } catch {
+    return new Error(null);
+  }
+}
+
+export function removeItem(storage, keyName) {
+  storage.removeItem(keyName);
+}
+
+export function clear(storage) {
+  storage.clear();
+}
+
+function null_or(val) {
+  if (val !== null) {
+    return new Ok(val);
+  } else {
+    return new Error(null);
+  }
+}

--- a/test/javascript/storage_test.gleam
+++ b/test/javascript/storage_test.gleam
@@ -1,0 +1,85 @@
+import gleam/list
+import gleeunit/should
+import plinth/javascript/storage
+
+pub fn get_throw_test() {
+  use <- run(True, False)
+  should.be_error(storage.local())
+  should.be_error(storage.session())
+}
+
+pub fn get_undef_test() {
+  use <- run(False, True)
+  should.be_error(storage.local())
+  should.be_error(storage.session())
+}
+
+pub fn get_set_test() {
+  use <- run(False, False)
+  let assert Ok(local) = storage.local()
+  should.be_ok(storage.set_item(local, "Foo", "Bar"))
+  should.equal(storage.get_item(local, "Foo"), Ok("Bar"))
+}
+
+pub fn set_limit_test() {
+  use <- run(False, False)
+  let assert Ok(session) = storage.session()
+  should.be_ok(storage.set_item(session, "Foo1", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo2", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo3", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo4", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo5", "Bar"))
+  should.be_error(storage.set_item(session, "Foo6", "Bar"))
+}
+
+pub fn length_test() {
+  use <- run(False, False)
+  let assert Ok(local) = storage.local()
+  should.be_ok(storage.set_item(local, "Foo", "Bar"))
+  should.be_ok(storage.set_item(local, "Foo2", "Bar"))
+  should.equal(storage.length(local), 2)
+}
+
+pub fn key_test() {
+  use <- run(False, False)
+  let assert Ok(local) = storage.local()
+  should.be_ok(storage.set_item(local, "Foo1", "Bar1"))
+  should.be_ok(storage.set_item(local, "Foo2", "Bar2"))
+  should.be_ok(storage.set_item(local, "Foo3", "Bar3"))
+  should.be_ok(storage.set_item(local, "Foo4", "Bar4"))
+  should.be_ok(storage.set_item(local, "Foo5", "Bar5"))
+
+  let indexes = [0, 1, 2, 3, 4]
+  let keys = list.try_map(indexes, fn(i) { storage.key(local, i) })
+  should.equal(keys, Ok(["Foo1", "Foo2", "Foo3", "Foo4", "Foo5"]))
+}
+
+pub fn key_fail_test() {
+  use <- run(False, False)
+  let assert Ok(local) = storage.local()
+  should.be_error(storage.key(local, 1))
+}
+
+pub fn remove_test() {
+  use <- run(False, False)
+  let assert Ok(local) = storage.local()
+  should.equal(storage.remove_item(local, "not here"), Nil)
+  should.be_ok(storage.set_item(local, "Foo", "Bar"))
+  should.equal(storage.remove_item(local, "Foo"), Nil)
+  should.be_error(storage.get_item(local, "Foo"))
+}
+
+pub fn clear_test() {
+  use <- run(False, False)
+  let assert Ok(session) = storage.session()
+  should.be_ok(storage.set_item(session, "Foo1", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo2", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo3", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo4", "Bar"))
+  should.be_ok(storage.set_item(session, "Foo5", "Bar"))
+  storage.clear(session)
+  should.equal(storage.length(session), 0)
+}
+
+@external(javascript, "../storage_test_ffi.mjs", "runWithMockStorage")
+fn run(should_throw: Bool, should_undef: Bool, callback: fn() -> a) -> Nil

--- a/test/plinth_test.gleam
+++ b/test/plinth_test.gleam
@@ -1,12 +1,5 @@
 import gleeunit
-import gleeunit/should
 
 pub fn main() {
   gleeunit.main()
-}
-
-// gleeunit test functions end in `_test`
-pub fn hello_world_test() {
-  1
-  |> should.equal(1)
 }

--- a/test/storage_test_ffi.mjs
+++ b/test/storage_test_ffi.mjs
@@ -1,0 +1,96 @@
+const ITEM_LIMIT = 5;
+
+class Storage {
+  #items;
+
+  constructor() {
+    this.#items = new Map();
+  }
+
+  get length() {
+    return this.#items.size;
+  }
+
+  key(index) {
+    let i = 0;
+    for (const k of this.#items.keys()) {
+      if (i === index) {
+        return k;
+      }
+
+      ++i;
+    }
+
+    return null;
+  }
+
+  getItem(k) {
+    return this.#items.get(k) || null;
+  }
+
+  setItem(k, v) {
+    if (this.#items.size === ITEM_LIMIT) {
+      throw new Error("Full!");
+    }
+
+    this.#items.set(k, v);
+  }
+
+  removeItem(k) {
+    this.#items.delete(k);
+  }
+
+  clear() {
+    this.#items.clear();
+  }
+}
+
+function getter(type, shouldThrow, shouldUndef) {
+  if (shouldThrow) {
+    throw new Error("ARGBL");
+  } else if (shouldUndef) {
+    return undefined;
+  } else {
+    return new Storage();
+  }
+}
+
+export function runWithMockStorage(shouldThrow, shouldUndef, callback) {
+  const oldStorage = globalThis.Storage;
+  const oldLocal = globalThis.localStorage;
+  const oldSession = globalThis.sessionStorage;
+
+  Object.defineProperty(globalThis, "Storage", {
+    value: Storage,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    get() {
+      return getter("localStorage", shouldThrow, shouldUndef);
+    },
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "sessionStorage", {
+    get() {
+      return getter("sessionStorage", shouldThrow, shouldUndef);
+    },
+    configurable: true,
+  });
+
+  try {
+    callback();
+  } finally {
+    Object.defineProperty(globalThis, "Storage", {
+      value: oldStorage,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      value: oldLocal,
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, "sessionStorage", {
+      value: oldSession,
+      configurable: true,
+    });
+  }
+}


### PR DESCRIPTION
This adds `localStorage` and `sessionStorage`. The functions follow https://developer.mozilla.org/en-US/docs/Web/API/Storage very closely and only operate on strings (higher level operation is left for the user or another package). I tried to guard all the ways the code could fail. I used `globalThis` instead of `window` so that I could mock it in tests.

Let me know what you think.