### PR TITLE
Bump gleam_json dependency

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -1,5 +1,5 @@
 name = "plinth"
-version = "0.1.9"
+version = "0.1.10"
 description = "Bindings to Node.js and browser platform APIs"
 target = "javascript"
 
@@ -14,7 +14,7 @@ gleam = ">= 0.32.0"
 [dependencies]
 gleam_stdlib = "~> 0.29"
 gleam_javascript = "~> 0.4"
-gleam_json = "~> 0.7"
+gleam_json = "~> 0.7 or ~> 1.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_javascript", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "B5E05F479C52217C02BA2E8FC650A716BFB62D4F8D20A90909C908598E12FBE0" },
-  { name = "gleam_json", version = "0.7.0", build_tools = ["gleam"], requirements = ["thoas", "gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "CB405BD93A8828BCD870463DE29375E7B2D252D9D124C109E5B618AAC00B86FC" },
-  { name = "gleam_stdlib", version = "0.33.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3CEAD7B153D896499C78390B22CC968620C27500C922AED3A5DD7B536F922B25" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
+  { name = "gleam_javascript", version = "0.8.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleam_javascript", source = "hex", outer_checksum = "14D5B7E1A70681E0776BF0A0357F575B822167960C844D3D3FA114D3A75F05A8" },
+  { name = "gleam_json", version = "1.0.0", build_tools = ["gleam"], requirements = ["thoas", "gleam_stdlib"], otp_app = "gleam_json", source = "hex", outer_checksum = "8B197DD5D578EA6AC2C0D4BDC634C71A5BCA8E7DB5F47091C263ECB411A60DF3" },
+  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleeunit", version = "1.0.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D364C87AFEB26BDB4FB8A5ABDE67D635DC9FA52D6AB68416044C35B096C6882D" },
   { name = "thoas", version = "0.4.1", build_tools = ["rebar3"], requirements = [], otp_app = "thoas", source = "hex", outer_checksum = "4918D50026C073C4AB1388437132C77A6F6F7C8AC43C60C13758CC0ADCE2134E" },
 ]
 
 [requirements]
 gleam_javascript = { version = "~> 0.4" }
-gleam_json = { version = "~> 0.7" }
+gleam_json = { version = "~> 0.7 or ~> 1.0" }
 gleam_stdlib = { version = "~> 0.29" }
 gleeunit = { version = "~> 1.0" }


### PR DESCRIPTION
This bumps the `gleam_json` dependency, allowing projects that require 1.0.0 to use it.

Unit tests pass.