### PR TITLE
Add keyboard events

### DIFF
--- a/src/event_ffi.mjs
+++ b/src/event_ffi.mjs
@@ -1,3 +1,22 @@
 export function target(event) {
   return event.target;
 }
+
+export function constructorName(value) {
+  return value.constructor.name;
+}
+
+export function toKeyboardEventUnsafe(event) {
+  return {
+    event,
+    alt_key: event.altKey,
+    code: event.code,
+    ctrl_key: event.ctrlKey,
+    is_composing: event.isComposing,
+    key: event.key,
+    location: event.location,
+    meta_key: event.meta_key,
+    repeat: event.repeat,
+    shift_key: event.shift_key,
+  };
+}

--- a/src/plinth/browser/event.gleam
+++ b/src/plinth/browser/event.gleam
@@ -2,5 +2,33 @@ import plinth/browser/element.{type Element}
 
 pub type Event
 
+pub type KeyboardEvent {
+  KeyboardEvent(
+    event: Event,
+    alt_key: Bool,
+    code: String,
+    ctrl_key: Bool,
+    is_composing: Bool,
+    key: String,
+    location: Int,
+    meta_key: Bool,
+    repeat: Bool,
+    shift_key: Bool,
+  )
+}
+
+@external(javascript, "../../event_ffi.mjs", "constructorName")
+fn constructor_name(value: a) -> String
+
+@external(javascript, "../../event_ffi.mjs", "toKeyboardEventUnsafe")
+fn to_keyboard_event_unsafe(event: Event) -> KeyboardEvent
+
+pub fn as_keyboard_event(event: Event) -> Result(KeyboardEvent, Nil) {
+  case constructor_name(event) {
+    "KeyboardEvent" -> Ok(to_keyboard_event_unsafe(event))
+    _ -> Error(Nil)
+  }
+}
+
 @external(javascript, "../../event_ffi.mjs", "target")
 pub fn target(event: Event) -> Element

--- a/src/plinth/browser/window.gleam
+++ b/src/plinth/browser/window.gleam
@@ -1,6 +1,6 @@
 import gleam/dynamic
 import gleam/javascript/promise.{type Promise}
-import plinth/browser/event.{type Event}
+import plinth/browser/event.{type Event, type KeyboardEvent}
 
 pub type Window
 
@@ -12,6 +12,30 @@ pub fn alert(a: String) -> Nil
 
 @external(javascript, "../../window_ffi.mjs", "addEventListener")
 pub fn add_event_listener(type_: String, listener: fn(Event) -> Nil) -> Nil
+
+fn add_keyboard_event_listener(
+  type_: String,
+  listener: fn(KeyboardEvent) -> Nil,
+) -> Nil {
+  add_event_listener(type_, fn(e) {
+    case event.as_keyboard_event(e) {
+      Ok(e) -> listener(e)
+      Error(_) -> Nil
+    }
+  })
+}
+
+pub fn add_event_listener_keypress(listener: fn(KeyboardEvent) -> Nil) -> Nil {
+  add_keyboard_event_listener("keypress", listener)
+}
+
+pub fn add_event_listener_keydown(listener: fn(KeyboardEvent) -> Nil) -> Nil {
+  add_keyboard_event_listener("keydown", listener)
+}
+
+pub fn add_event_listener_keyup(listener: fn(KeyboardEvent) -> Nil) -> Nil {
+  add_keyboard_event_listener("keyup", listener)
+}
 
 pub type WakeLockSentinal
 


### PR DESCRIPTION
Adds function `as_keyboard_event` to `event.gleam` so you can access items specific to the [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) variant.

Example usage:

```gleam
window.add_event_listener("keydown", fn(e) {
  case event.as_keyboard_event(e) {
    Ok(e) -> 
      case #(e.key, e.shift_key) {
        #("ArrowLeft", False) -> dispatch(MoveLeft)
        #("ArrowRight", False) -> dispatch(MoveRight)
        #("ArrowLeft", True) -> dispatch(JumpLeft)
        #("ArrowRight", True) -> dispatch(JumpRight)
        _ -> Nil
      }
    Error(_) -> Nil
  }
})
```

This can be extended later on to handle other variants like `MouseEvent` or `PointerEvent`.

I also added convenience functions `add_event_listener_keydown`, `add_event_listener_keyup`, and `add_event_listener_keypress` that already does the converting for you. So you can alternatively write the above like so:

```gleam
window.add_event_listener_keydown(fn(e) {
  case #(e.key, e.shift_key) {
    #("ArrowLeft", False) -> dispatch(MoveLeft)
    #("ArrowRight", False) -> dispatch(MoveRight)
    #("ArrowLeft", True) -> dispatch(JumpLeft)
    #("ArrowRight", True) -> dispatch(JumpRight)
    _ -> Nil
  }
})
```