### PR TITLE
Make set_timeout use friendly

### DIFF
--- a/src/global_ffi.mjs
+++ b/src/global_ffi.mjs
@@ -1,4 +1,4 @@
-export function setTimeout(callback, delay) {
+export function setTimeout(delay, callback) {
   globalThis.setTimeout(callback, delay);
 }
 

--- a/src/plinth/javascript/global.gleam
+++ b/src/plinth/javascript/global.gleam
@@ -9,4 +9,4 @@ pub fn decode_uri_component(a: String) -> String
 
 // https://tc39.es/ecma262/multipage/global-object.html#sec-globalthis
 @external(javascript, "../../global_ffi.mjs", "setTimeout")
-pub fn set_timeout(callback: fn(Nil) -> Nil, delay: Int) -> Nil
+pub fn set_timeout(delay: Int, callback: fn() -> anything) -> Nil


### PR DESCRIPTION
Hello! Thanks for this library, it was useful in my stream today.

One thing I thought would be nice would be if you could `use` `set_timeout` and have a relaxed return value, so instead of writing this:

```gleam
toggle_class(el, "active")
set_timeout(
  fn(_nil) {
    toggle_class(el, "active")
    Nil
  },
  1000,
)
```

I could write this:

```gleam
toggle_class(el, "active")
use <- set_timeout(1000)
toggle_class(el, "active")
```

Let me know what you think!

Thank you.