### PR TITLE
Feat: `set_value`

### DIFF
--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -49,6 +49,10 @@ export function value(element) {
   return new Error();
 }
 
+export function setValue(element, value) {
+  element.value = value;
+}
+
 export function selectionStart(element) {
   let value = element.selectionStart;
   if (value != undefined) {

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -30,6 +30,9 @@ pub fn append_child(parent: Element, child: Element) -> Nil
 @external(javascript, "../../element_ffi.mjs", "value")
 pub fn value(element: Element) -> Result(String, Nil)
 
+@external(javascript, "../../element_ffi.mjs", "setValue")
+pub fn set_value(element: Element, value: String) -> Nil
+
 // Inputs
 @external(javascript, "../../element_ffi.mjs", "focus")
 pub fn focus(element: Element) -> Nil


### PR DESCRIPTION
Quick `set_value` function for elements. Useful for clearing/pre-filling inputs and the like. Couldn't find an existing way of doing this, but let me know if I missed something!