### PR TITLE
Add screen and scroll property on window

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "26.0.2"
-          gleam-version: "1.0"
+          gleam-version: "1.2"
           rebar3-version: "3"
           # elixir-version: "1.15.4"
       - run: gleam format --check src test

--- a/src/plinth/browser/window.gleam
+++ b/src/plinth/browser/window.gleam
@@ -59,6 +59,24 @@ pub fn outer_height(window: Window) -> Int
 @external(javascript, "../../window_ffi.mjs", "outerWidth")
 pub fn outer_width(window: Window) -> Int
 
+@external(javascript, "../../window_ffi.mjs", "screenX")
+pub fn screen_x(window: Window) -> Int
+
+@external(javascript, "../../window_ffi.mjs", "screenY")
+pub fn screen_y(window: Window) -> Int
+
+@external(javascript, "../../window_ffi.mjs", "screenTop")
+pub fn screen_top(window: Window) -> Int
+
+@external(javascript, "../../window_ffi.mjs", "screenLeft")
+pub fn screen_left(window: Window) -> Int
+
+@external(javascript, "../../window_ffi.mjs", "scrollX")
+pub fn scroll_x(window: Window) -> Int
+
+@external(javascript, "../../window_ffi.mjs", "scrollY")
+pub fn scroll_y(window: Window) -> Int
+
 @external(javascript, "../../worker_ffi.mjs", "onMessage")
 pub fn on_message(worker: Window, handle: fn(Json) -> Nil) -> Nil
 

--- a/src/window_ffi.mjs
+++ b/src/window_ffi.mjs
@@ -36,7 +36,6 @@ export function setLocation(w, url) {
   w.location.href = url;
 }
 
-
 export function reload() {
   return window.location.reload();
 }
@@ -81,6 +80,30 @@ export function outerHeight(w) {
 
 export function outerWidth(w) {
   return w.outerWidth;
+}
+
+export function screenX(w) {
+  return w.screenX;
+}
+
+export function screenY(w) {
+  return w.screenY;
+}
+
+export function screenTop(w) {
+  return w.screenTop;
+}
+
+export function screenLeft(w) {
+  return w.screenLeft;
+}
+
+export function scrollX(w) {
+  return w.scrollX;
+}
+
+export function scrollY(w) {
+  return w.scrollY;
 }
 
 export function open(url, target, features) {

--- a/test/javascript/big_int_test.gleam
+++ b/test/javascript/big_int_test.gleam
@@ -1,5 +1,5 @@
-import plinth/javascript/big_int
 import gleeunit/should
+import plinth/javascript/big_int
 
 pub fn add_test() {
   big_int.from_int(1)


### PR DESCRIPTION
Hi!

This PR contains bindings for `window`, giving the ability to use `scrollX`, `scrollY`, `screenX`, `screenY`, `screenLeft` & `screenTop` in Gleam directly.

It also uses the last version of gleam and fixes the formatting to get the GitHub Actions working again.