### PR TITLE
Allow access to document.hidden and document.visibilityState

### DIFF
--- a/src/document_ffi.mjs
+++ b/src/document_ffi.mjs
@@ -39,3 +39,11 @@ export function getElementById(id) {
 export function readyState() {
   return document.readyState;
 }
+
+export function hidden() {
+  return document.hidden;
+}
+
+export function visibilityState() {
+  return document.visibilityState;
+}

--- a/src/plinth/browser/document.gleam
+++ b/src/plinth/browser/document.gleam
@@ -25,3 +25,13 @@ pub fn get_element_by_id(id: String) -> Result(Element, Nil)
 
 @external(javascript, "../../document_ffi.mjs", "readyState")
 pub fn ready_state() -> String
+
+/// Get the [`hidden`](https://developer.mozilla.org/en-US/docs/Web/API/Document/hidden)
+/// attribute value of the current document
+@external(javascript, "../../document_ffi.mjs", "hidden")
+pub fn hidden() -> Bool
+
+/// Get the [`visibilityState`](https://developer.mozilla.org/en-US/docs/Web/API/Document/visibilityState)
+/// attribute value of the current document. It should be either `"visible"` or `"hidden"`.
+@external(javascript, "../../document_ffi.mjs", "visibilityState")
+pub fn visibility_state() -> String


### PR DESCRIPTION
We provide functions to return the values of these read only properties to allow users to query and act on them.

I hope these are ok. Happy to make changes as needed.

We could have a custom type with `Visible` and `Hidden` values if we'd like to go in that direction.