### PR TITLE
Call preventDefault & stopPropagation in respective FFI

### DIFF
--- a/src/event_ffi.mjs
+++ b/src/event_ffi.mjs
@@ -10,11 +10,10 @@ export function keyCode(event) {
   return event.keyCode;
 }
 
-
 export function preventDefault(event) {
-  return event.preventDefault;
+  return event.preventDefault();
 }
 
 export function stopPropagation(event) {
-  return event.stopPropagation;
+  return event.stopPropagation();
 }


### PR DESCRIPTION
Right now, when calling `event.prevent_default(event)` & `event.stop_propagation(event)`, nothing happens. This PR fixes that behaviour.