### PR TITLE
feat(child_process): add `spawn`

### DIFF
--- a/src/child_process_ffi.mjs
+++ b/src/child_process_ffi.mjs
@@ -1,0 +1,4 @@
+import child_process from "node:child_process"
+
+export const spawn = (cmd, args) =>
+  child_process.spawn(cmd, args.toArray())

--- a/src/child_process_ffi.mjs
+++ b/src/child_process_ffi.mjs
@@ -2,3 +2,6 @@ import child_process from "node:child_process"
 
 export const spawn = (cmd, args) =>
   child_process.spawn(cmd, args.toArray())
+
+export const kill = (childProcess) =>
+  childProcess.kill()

--- a/src/child_process_ffi.mjs
+++ b/src/child_process_ffi.mjs
@@ -1,7 +1,11 @@
+import { Ok, Error } from "./gleam.mjs";
 import child_process from "node:child_process"
+
+export const kill = (childProcess) =>
+  childProcess.kill()
 
 export const spawn = (cmd, args) =>
   child_process.spawn(cmd, args.toArray())
 
-export const kill = (childProcess) =>
-  childProcess.kill()
+export const stdin = (childProcess) =>
+  childProcess.stdin ? new Ok(childProcess.stdin) : new Error()

--- a/src/plinth/node/child_process.gleam
+++ b/src/plinth/node/child_process.gleam
@@ -1,8 +1,6 @@
 import plinth/node/stream
 
-pub type ChildProcess {
-  ChildProcess(stdin: stream.Writable)
-}
+pub type ChildProcess
 
 @external(javascript, "child_process", "exec")
 pub fn exec(command: String) -> ChildProcess
@@ -12,3 +10,6 @@ pub fn spawn(command: String, arguments: List(String)) -> ChildProcess
 
 @external(javascript, "../../child_process_ffi.mjs", "kill")
 pub fn kill(child_process: ChildProcess) -> Nil
+
+@external(javascript, "../../child_process_ffi.mjs", "stdin")
+pub fn stdin(child_process: ChildProcess) -> Result(stream.Writable, Nil)

--- a/src/plinth/node/child_process.gleam
+++ b/src/plinth/node/child_process.gleam
@@ -1,9 +1,7 @@
-pub type ChildProcess {
-  ChildProcess(stdin: Stdin)
-}
+import plinth/node/stream
 
-pub type Stdin {
-  Stdin(write: fn(String) -> Nil)
+pub type ChildProcess {
+  ChildProcess(stdin: stream.Writable)
 }
 
 @external(javascript, "child_process", "exec")

--- a/src/plinth/node/child_process.gleam
+++ b/src/plinth/node/child_process.gleam
@@ -1,2 +1,13 @@
+pub type ChildProcess {
+  ChildProcess(kill: fn() -> Nil, stdin: Stdin)
+}
+
+pub type Stdin {
+  Stdin(write: fn(String) -> Nil)
+}
+
 @external(javascript, "child_process", "exec")
-pub fn exec(command: String) -> Nil
+pub fn exec(command: String) -> ChildProcess
+
+@external(javascript, "../../child_process_ffi.mjs", "spawn")
+pub fn spawn(command: String, arguments: List(String)) -> ChildProcess

--- a/src/plinth/node/child_process.gleam
+++ b/src/plinth/node/child_process.gleam
@@ -1,5 +1,5 @@
 pub type ChildProcess {
-  ChildProcess(kill: fn() -> Nil, stdin: Stdin)
+  ChildProcess(stdin: Stdin)
 }
 
 pub type Stdin {
@@ -11,3 +11,6 @@ pub fn exec(command: String) -> ChildProcess
 
 @external(javascript, "../../child_process_ffi.mjs", "spawn")
 pub fn spawn(command: String, arguments: List(String)) -> ChildProcess
+
+@external(javascript, "../../child_process_ffi.mjs", "kill")
+pub fn kill(child_process: ChildProcess) -> Nil

--- a/src/plinth/node/stream.gleam
+++ b/src/plinth/node/stream.gleam
@@ -1,0 +1,4 @@
+pub type Writable
+
+@external(javascript, "../../stream_ffi.mjs", "write")
+pub fn write(on writable: Writable, chunk chunk: String) -> Nil

--- a/src/stream_ffi.mjs
+++ b/src/stream_ffi.mjs
@@ -1,0 +1,2 @@
+export const write = (writable, chunk) =>
+  writable.write(chunk)


### PR DESCRIPTION
Just found this package and it's great for my Gleam application, it's just missing the `spawn` command from the `child_process` module, so I'm adding it here in this PR.
I'm also adding the type `ChildProcess`, but not with all the fields and methods it has, only those I need.