### PR TITLE
feat: add origin and pathname for browser

### DIFF
--- a/src/plinth/browser/window.gleam
+++ b/src/plinth/browser/window.gleam
@@ -29,6 +29,12 @@ pub fn location_of(window: Window) -> Result(String, String)
 @external(javascript, "../../window_ffi.mjs", "setLocation")
 pub fn set_location(window: Window, url: String) -> Nil
 
+@external(javascript, "../../window_ffi.mjs", "origin")
+pub fn origin() -> String
+
+@external(javascript, "../../window_ffi.mjs", "pathname")
+pub fn pathname() -> String
+
 // reload exists on the location object but exposed at top level here
 @external(javascript, "../../window_ffi.mjs", "reload")
 pub fn reload() -> Nil

--- a/src/window_ffi.mjs
+++ b/src/window_ffi.mjs
@@ -36,6 +36,14 @@ export function setLocation(w, url) {
   w.location.href = url;
 }
 
+export function origin() {
+  return window.location.origin;
+}
+
+export function pathname() {
+  return window.location.pathname;
+}
+
 export function reload() {
   return window.location.reload();
 }


### PR DESCRIPTION
Particularly useful when calling APIs in SSR Lustre - `lustre_http` requires a full URL and disallows relative paths, which is troublesome when you want to have multiple deployments of an app.