### PR TITLE
feat(dialog): Add showModal and close functions for dialogs

### DIFF
--- a/src/dialog_ffi.mjs
+++ b/src/dialog_ffi.mjs
@@ -1,0 +1,11 @@
+export function showModal(element) {
+    if (!element || !(element instanceof HTMLDialogElement)) return;
+
+    element.showModal();
+}
+
+export function closeModal(element) {
+    if (!element || !(element instanceof HTMLDialogElement)) return;
+
+    element.close();
+}

--- a/src/plinth/browser/dialog.gleam
+++ b/src/plinth/browser/dialog.gleam
@@ -1,0 +1,7 @@
+import plinth/browser/element.{type Element}
+
+@external(javascript, "../../dialog_ffi.mjs", "showModal")
+pub fn show_modal(element: Element) -> Nil
+
+@external(javascript, "../../dialog_ffi.mjs", "closeModal")
+pub fn close_modal(element: Element) -> Nil


### PR DESCRIPTION
There wasn't functions to call the showModal and close functions for dialogs, so here they are !