### PR TITLE
add classList methods to element

### DIFF
--- a/src/dom_token_list_ffi.mjs
+++ b/src/dom_token_list_ffi.mjs
@@ -9,9 +9,9 @@ export function remove(domTokenList, tokens) {
 }
 
 export function toggle(domTokenList, token, force) {
-  domTokenList.toggle(token, unwrap(force, undefined));
+  return domTokenList.toggle(token, unwrap(force, undefined));
 }
 
 export function replace(domTokenList, from, to) {
-  domTokenList.replace(from, to);
+  return domTokenList.replace(from, to);
 }

--- a/src/dom_token_list_ffi.mjs
+++ b/src/dom_token_list_ffi.mjs
@@ -1,0 +1,17 @@
+import { unwrap } from "../gleam_stdlib/gleam/option.mjs";
+
+export function add(domTokenList, tokens) {
+  domTokenList.add(...tokens);
+}
+
+export function remove(domTokenList, tokens) {
+  domTokenList.remove(...tokens);
+}
+
+export function toggle(domTokenList, token, force) {
+  domTokenList.toggle(token, unwrap(force, undefined));
+}
+
+export function replace(domTokenList, from, to) {
+  domTokenList.replace(from, to);
+}

--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -175,3 +175,19 @@ export function setTextContent(element, text) {
 export function contains(element, other) {
   return element.contains(other);
 }
+
+export function addClass(element, classnames) {
+  element.classList.add(...classnames);
+}
+
+export function removeClass(element, classnames) {
+  element.classList.remove(...classnames);
+}
+
+export function toggleClass(element, classname, predicate) {
+  element.classList.toggle(classname, predicate ?? true);
+}
+
+export function replaceClass(element, from, to) {
+  element.classList.replace(from, to);
+}

--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -176,6 +176,6 @@ export function contains(element, other) {
   return element.contains(other);
 }
 
-export function getClassList(element) {
+export function classList(element) {
   return element.classList;
 }

--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -176,18 +176,6 @@ export function contains(element, other) {
   return element.contains(other);
 }
 
-export function addClass(element, classnames) {
-  element.classList.add(...classnames);
-}
-
-export function removeClass(element, classnames) {
-  element.classList.remove(...classnames);
-}
-
-export function toggleClass(element, classname, predicate) {
-  element.classList.toggle(classname, predicate ?? true);
-}
-
-export function replaceClass(element, from, to) {
-  element.classList.replace(from, to);
+export function getClassList(element) {
+  return element.classList;
 }

--- a/src/plinth/browser/dom_token_list.gleam
+++ b/src/plinth/browser/dom_token_list.gleam
@@ -1,0 +1,24 @@
+import gleam/javascript/array.{type Array}
+import gleam/option.{type Option}
+
+pub type DomTokenList
+
+@external(javascript, "../../dom_token_list_ffi.mjs", "add")
+pub fn add(dom_token_list: DomTokenList, tokens: Array(String)) -> Nil
+
+@external(javascript, "../../dom_token_list_ffi.mjs", "remove")
+pub fn remove(dom_token_list: DomTokenList, tokens: Array(String)) -> Nil
+
+@external(javascript, "../../dom_token_list_ffi.mjs", "toggle")
+pub fn toggle(
+  dom_token_list: DomTokenList,
+  token: String,
+  force force: Option(Bool),
+) -> Nil
+
+@external(javascript, "../../dom_token_list_ffi.mjs", "replace")
+pub fn replace(
+  dom_token_list: DomTokenList,
+  from_token: String,
+  to_token: String,
+) -> Nil

--- a/src/plinth/browser/dom_token_list.gleam
+++ b/src/plinth/browser/dom_token_list.gleam
@@ -3,22 +3,40 @@ import gleam/option.{type Option}
 
 pub type DomTokenList
 
+/// The `add()` method adds the given tokens to the list, omitting any that are already present
+/// https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/add
+///
 @external(javascript, "../../dom_token_list_ffi.mjs", "add")
 pub fn add(dom_token_list: DomTokenList, tokens: Array(String)) -> Nil
 
+/// The `remove()` method removes the specified tokens from the list
+/// https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/remove
+///
 @external(javascript, "../../dom_token_list_ffi.mjs", "remove")
 pub fn remove(dom_token_list: DomTokenList, tokens: Array(String)) -> Nil
 
+/// The `toggle()` method removes an existing token from the list and returns false.
+/// If the token doesn't exist it's added and the function returns true.
+/// https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/toggle
+///
+/// `force`: If included, turns the toggle into a one way-only operation.
+///   If set to false, then token will only be removed, but not added.
+///   If set to true, then token will only be added, but not removed.
+///
 @external(javascript, "../../dom_token_list_ffi.mjs", "toggle")
 pub fn toggle(
   dom_token_list: DomTokenList,
   token: String,
   force force: Option(Bool),
-) -> Nil
+) -> Bool
 
+/// The `replace()` method replaces an existing token with a new token.
+/// If the first token doesn't exist, `replace()` returns false immediately,
+/// without adding the new token to the token list.
+/// https://developer.mozilla.org/en-US/docs/Web/API/DOMTokenList/replace
 @external(javascript, "../../dom_token_list_ffi.mjs", "replace")
 pub fn replace(
   dom_token_list: DomTokenList,
   from_token: String,
   to_token: String,
-) -> Nil
+) -> Bool

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -172,5 +172,5 @@ pub fn get_checked(element: Element) -> Bool
 @external(javascript, "../../element_ffi.mjs", "contains")
 pub fn contains(element: Element, other: Element) -> Bool
 
-@external(javascript, "../../element_ffi.mjs", "getClassList")
-pub fn get_class_list(element: Element) -> DomTokenList
+@external(javascript, "../../element_ffi.mjs", "classList")
+pub fn class_list(element: Element) -> DomTokenList

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -190,7 +190,15 @@ pub fn toggle_class(element: Element, classname: String) -> Nil {
 }
 
 @external(javascript, "../../element_ffi.mjs", "toggleClass")
-pub fn toggle_class_when(element: Element, classname: String, predicate: Bool) -> Nil
+pub fn toggle_class_when(
+  element: Element,
+  classname: String,
+  predicate: Bool,
+) -> Nil
 
 @external(javascript, "../../element_ffi.mjs", "replaceClass")
-pub fn replace_class(element: Element, from_class: String, to_class: String) -> Nil
+pub fn replace_class(
+  element: Element,
+  from_class: String,
+  to_class: String,
+) -> Nil

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -170,3 +170,27 @@ pub fn get_checked(element: Element) -> Bool
 
 @external(javascript, "../../element_ffi.mjs", "contains")
 pub fn contains(element: Element, other: Element) -> Bool
+
+pub fn add_class(element: Element, classname: String) -> Nil {
+  add_classes(element, [classname])
+}
+
+@external(javascript, "../../element_ffi.mjs", "addClass")
+pub fn add_classes(element: Element, classnames: List(String)) -> Nil
+
+pub fn remove_class(element: Element, classname: String) -> Nil {
+  remove_classes(element, [classname])
+}
+
+@external(javascript, "../../element_ffi.mjs", "removeClass")
+pub fn remove_classes(element: Element, classnames: List(String)) -> Nil
+
+pub fn toggle_class(element: Element, classname: String) -> Nil {
+  toggle_class_when(element, classname, True)
+}
+
+@external(javascript, "../../element_ffi.mjs", "toggleClass")
+pub fn toggle_class_when(element: Element, classname: String, predicate: Bool) -> Nil
+
+@external(javascript, "../../element_ffi.mjs", "replaceClass")
+pub fn replace_class(element: Element, from_class: String, to_class: String) -> Nil

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -1,5 +1,6 @@
 import gleam/dynamic.{type Dynamic, DecodeError}
 import gleam/javascript/promise.{type Promise}
+import plinth/browser/dom_token_list.{type DomTokenList}
 import plinth/browser/event.{type Event}
 
 pub type Element
@@ -171,34 +172,5 @@ pub fn get_checked(element: Element) -> Bool
 @external(javascript, "../../element_ffi.mjs", "contains")
 pub fn contains(element: Element, other: Element) -> Bool
 
-pub fn add_class(element: Element, classname: String) -> Nil {
-  add_classes(element, [classname])
-}
-
-@external(javascript, "../../element_ffi.mjs", "addClass")
-pub fn add_classes(element: Element, classnames: List(String)) -> Nil
-
-pub fn remove_class(element: Element, classname: String) -> Nil {
-  remove_classes(element, [classname])
-}
-
-@external(javascript, "../../element_ffi.mjs", "removeClass")
-pub fn remove_classes(element: Element, classnames: List(String)) -> Nil
-
-pub fn toggle_class(element: Element, classname: String) -> Nil {
-  toggle_class_when(element, classname, True)
-}
-
-@external(javascript, "../../element_ffi.mjs", "toggleClass")
-pub fn toggle_class_when(
-  element: Element,
-  classname: String,
-  predicate: Bool,
-) -> Nil
-
-@external(javascript, "../../element_ffi.mjs", "replaceClass")
-pub fn replace_class(
-  element: Element,
-  from_class: String,
-  to_class: String,
-) -> Nil
+@external(javascript, "../../element_ffi.mjs", "getClassList")
+pub fn get_class_list(element: Element) -> DomTokenList


### PR DESCRIPTION
Hello there,

I was looking for handling `classList` and stuff but the API was not there, so I added it.

Here is how to use it in gleam code:
```gleam
element.remove_classes(el, ["to-be-deleted", "to-be-removed"])
element.add_class(el, "new-class")
element.add_classes(el, ["and-two", "and-three"])
element.toggle_class(el, "toggled")
element.toggle_class_when(el, "toggled-with-predicate", element.inner_text(el) == "I should toggle as well")
element.replace_class(el, "new-class", "new-class-replaced")
```

Open to any changes, I don't know how _true_ to conventions I am (List vs Array for instance?).

If needed, here is the MDN page: https://developer.mozilla.org/en-US/docs/Web/API/Element/classList

Cheers!