### PR TITLE
switch from deprecated Date.getYear() to date.getFullYear()

### DIFF
--- a/src/date_ffi.mjs
+++ b/src/date_ffi.mjs
@@ -1,39 +1,39 @@
 export function now() {
-  return new Date();
+	return new Date();
 }
 
 export function new_(string) {
-  return new Date(string);
+	return new Date(string);
 }
 
 export function toISOString(d) {
-  return d.toISOString();
+	return d.toISOString();
 }
 
 export function year(d) {
-  return d.getYear();
+	return d.getFullYear();
 }
 
 export function month(d) {
-  return d.getMonth();
+	return d.getMonth();
 }
 
 export function day(d) {
-  return d.getDay();
+	return d.getDay();
 }
 
 export function date(d) {
-  return d.getDate();
+	return d.getDate();
 }
 
 export function hours(d) {
-  return d.getHours();
+	return d.getHours();
 }
 
 export function minutes(d) {
-  return d.getMinutes();
+	return d.getMinutes();
 }
 
 export function seconds(d) {
-  return d.getSeconds();
+	return d.getSeconds();
 }


### PR DESCRIPTION
the [Date.prototype.getYear()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getYear) function has been deprecated in favour of the much more reasonable [getFullYear()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getFullYear) function, which returns a full proper year instead of the above/below 100 number of getYear.

Considering this has been deprecated and provides a sub-optimal implementation, especially one that functions in a non-obvious way, this should be an easy change to make.