### PR TITLE
Implement `event.detail` & `event.property`

### DIFF
--- a/src/event_ffi.mjs
+++ b/src/event_ffi.mjs
@@ -59,3 +59,11 @@ export function metaKey(event) {
 export function shiftKey(event) {
   return event.shiftKey;
 }
+
+export function property(event, key) {
+  return event[key];
+}
+
+export function detail(event) {
+  return event.detail;
+}

--- a/src/plinth/browser/event.gleam
+++ b/src/plinth/browser/event.gleam
@@ -63,3 +63,9 @@ pub fn meta_key(event: Event(UIEvent(KeyboardEvent))) -> Bool
 
 @external(javascript, "../../event_ffi.mjs", "shiftKey")
 pub fn shift_key(event: Event(UIEvent(KeyboardEvent))) -> Bool
+
+@external(javascript, "../../event_ffi.mjs", "property")
+pub fn property(event: Event(t), property: String) -> Dynamic
+
+@external(javascript, "../../event_ffi.mjs", "detail")
+pub fn detail(event: Event(t)) -> Dynamic


### PR DESCRIPTION
Hey! Thanks so much for this package; it's making my life much easier around some tricky JS interop!

I found myself looking to get `event.detail` as a `Dynamic`, but I'm pretty sure there wasn't anything extant on `plinth/browser/event` to accomplish this, so I've added:

```gleam
pub fn detail(event: Event(t)) -> Dynamic
// to grab JS `event.detail` specifically

pub fn property(event: Event(t), property: String) -> Dynamic
// to grab an arbitrary property off of a JS event
```

Let me know if you'd like me to rename or move anything around.

Cheers,
Brad