### PR TITLE
Add binding for Element.querySelector

### DIFF
--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -183,3 +183,15 @@ export function contains(element, other) {
 export function classList(element) {
   return element.classList;
 }
+
+export function querySelector(element, selector) {
+  let found = element.querySelector(selector);
+  if (!found) {
+    return new Error();
+  }
+  return new Ok(found);
+}
+
+export function querySelectorAll(element, selector) {
+  return Array.from(element.querySelectorAll(selector));
+}

--- a/src/plinth/browser/document.gleam
+++ b/src/plinth/browser/document.gleam
@@ -1,15 +1,18 @@
-import gleam/javascript/array.{type Array}
 import gleam/javascript/promise.{type Promise}
 import plinth/browser/element.{type Element}
 import plinth/browser/event.{type Event}
 
 pub type Document
 
+/// Returns the first Element node within the document, in document order, that matches the specified selectors.
+/// Binding of [`Document.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelector).
 @external(javascript, "../../document_ffi.mjs", "querySelector")
 pub fn query_selector(selector: String) -> Result(Element, Nil)
 
+/// Returns a list of all the Element nodes within the document that match the specified selectors.
+/// Binding of [`Document.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Document/querySelectorAll).
 @external(javascript, "../../document_ffi.mjs", "querySelectorAll")
-pub fn query_selector_all(selector: String) -> Array(Element)
+pub fn query_selector_all(selector: String) -> List(Element)
 
 @external(javascript, "../../document_ffi.mjs", "addEventListener")
 pub fn add_event_listener(type_: String, listener: fn(Event(t)) -> Nil) -> Nil
@@ -26,8 +29,10 @@ pub fn body() -> Element
 @external(javascript, "../../document_ffi.mjs", "getElementById")
 pub fn get_element_by_id(id: String) -> Result(Element, Nil)
 
+/// Returns a list of elements with the given tag name.
+/// Binding of [`Document.getElementsByTagName`](https://developer.mozilla.org/en-US/docs/Web/API/Document/getElementsByTagName)
 @external(javascript, "../../document_ffi.mjs", "getElementsByTagName")
-pub fn get_elements_by_tag_name(tag_name: String) -> Array(Element)
+pub fn get_elements_by_tag_name(tag_name: String) -> List(Element)
 
 @external(javascript, "../../document_ffi.mjs", "readyState")
 pub fn ready_state() -> String

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -108,6 +108,20 @@ pub fn next_element_sibling(element: Element) -> Result(Element, Nil)
 @external(javascript, "../../element_ffi.mjs", "closest")
 pub fn closest(element: Element, selector: String) -> Result(Element, Nil)
 
+/// Returns the first element that is a descendant of the element on which it is invoked that matches the specified group of selectors.
+/// Binding of [`Element.querySelector`](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelector).
+@external(javascript, "../../element_ffi.mjs", "querySelector")
+pub fn query_selector(
+  element: Element,
+  selector: String,
+) -> Result(Element, Nil)
+
+/// Returns a list of elements matching the specified group of selectors
+/// which are descendants of the passed element.
+/// Binding of [`Element.querySelectorAll`](https://developer.mozilla.org/en-US/docs/Web/API/Element/querySelectorAll).
+@external(javascript, "../../element_ffi.mjs", "querySelectorAll")
+pub fn query_selector_all(element: Element, selector: String) -> List(Element)
+
 @external(javascript, "../../element_ffi.mjs", "requestFullscreen")
 pub fn request_fullscreen(element: Element) -> Promise(Result(Nil, String))
 

--- a/src/plinth/browser/shadow.gleam
+++ b/src/plinth/browser/shadow.gleam
@@ -1,4 +1,3 @@
-import gleam/javascript/array.{type Array}
 import plinth/browser/element.{type Element}
 
 pub type ShadowRoot
@@ -31,4 +30,4 @@ pub fn query_selector(
 pub fn query_selector_all(
   shadow_root: ShadowRoot,
   selector: String,
-) -> Array(Element)
+) -> List(Element)


### PR DESCRIPTION
This PR also:
- Adds binding for `Element.querySelectorAll`.
- Change the return type of `xxx.querySelectorAll` from `Array` to `List`, because in the JS side, these  methods retun `NodeList` or `HTMLCollection` which are meant to be immutable.

Quote:

> This interface was an [attempt to create an unmodifiable list](https://stackoverflow.com/questions/74630989/why-use-domstringlist-rather-than-an-array/74641156#74641156) and only continues to be supported to not break code that's already using it. Modern APIs represent list structures using types based on JavaScript [arrays](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array), thus making many array methods available, and at the same time imposing additional semantics on their usage (such as making their items read-only).