### PR TITLE
Fix element.query_selector

### DIFF
--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -230,7 +230,7 @@ export function querySelector(element, selector) {
   if (!found) {
     return new Error();
   }
-  return new Ok(found);
+  return Result$Ok(found);
 }
 
 export function querySelectorAll(element, selector) {


### PR DESCRIPTION
Hi! `plinth/browser/element`'s `query_selector` wasn't working for me, and I realized that the code was still using the outdated JavaScript API.

Here's the error message I got on the browser's console:

```
Uncaught ReferenceError: Ok is not defined
    querySelector element_ffi.mjs:233
    on_clicked_document app.gleam:1
```

So I changed `new Ok` to `Result$Ok` (like in #37) and now it works for me.

By the way, by grepping I didn't find any other case similar to this.