### PR TITLE
Add binding for Element matches() method.

### DIFF
--- a/src/element_ffi.mjs
+++ b/src/element_ffi.mjs
@@ -236,3 +236,7 @@ export function querySelector(element, selector) {
 export function querySelectorAll(element, selector) {
   return Array.from(element.querySelectorAll(selector));
 }
+
+export function matches(element, selector) {
+  return element.matches(selector);
+}

--- a/src/plinth/browser/element.gleam
+++ b/src/plinth/browser/element.gleam
@@ -227,3 +227,8 @@ pub fn contains(element: Element, other: Element) -> Bool
 
 @external(javascript, "../../element_ffi.mjs", "classList")
 pub fn class_list(element: Element) -> DomTokenList
+
+/// Checks if an element matches a given selector.
+/// Binding of [`Element.matches`](https://developer.mozilla.org/en-US/docs/Web/API/Element/matches).
+@external(javascript, "../../element_ffi.mjs", "matches")
+pub fn matches(element: Element, selector: String) -> Bool


### PR DESCRIPTION
https://caniuse.com/matchesselector
https://developer.mozilla.org/en-US/docs/Web/API/Element/matches
> The matches() method of the [Element](https://developer.mozilla.org/en-US/docs/Web/API/Element) interface tests whether the element would be selected by the specified [CSS selector](https://developer.mozilla.org/en-US/docs/Learn_web_development/Core/Styling_basics/Basic_selectors).